### PR TITLE
Remove load warning for not using SKETCHFAB or D3

### DIFF
--- a/index.php
+++ b/index.php
@@ -61,11 +61,15 @@
     <link rel="stylesheet" href="./editors/css/propertyVE.css" type="text/css" />
     <link rel="stylesheet" href="./editors/css/sequenceVE.css" type="text/css" />
     <?php
-    if (USE_SKETCHFAB) {
-      echo '<script type=\"text/javascript\" src=\"/sketchfab/sketchfab-viewer-1.8.2.js\"></script>';
+    if (defined("USE_SKETCHFAB") && USE_SKETCHFAB) {
+    ?>
+    <script type="text/javascript" src="/sketchfab/sketchfab-viewer-1.8.2.js"></script>
+    <?php
     }
-    if (USE_D3) {
-      echo '<script src=\"/d3/d3.js\"></script>';
+    if (defined("USE_D3") && USE_D3) {
+    ?>
+    <script src="/d3/d3.js"></script>
+    <?php
     }
     ?>
     <script src="/jquery/jquery-1.11.1.min.js"></script>


### PR DESCRIPTION
Here is the code to adjust index.php to include the .js code for sketchfab and D3.

See the config-sample.php  for configuring includes:
//Configure includes
  // include the sketchfab source
  if(!defined("USE_SKETCHFAB")) define("USE_SKETCHFAB","1");
  // include the d3path source
  if(!defined("USE_D3")) define("USE_D3","1");
