### PR TITLE
misc. fixes for terms, paleoVE and token.php

### DIFF
--- a/admin/app.py
+++ b/admin/app.py
@@ -24,7 +24,7 @@ def default_app():
 
     @app.route("/")
     def index():
-        return "<h2> READ Central Admin coming soon.</h2> <br/> <span>Type going direct to admin your database using localhost:8001/<i>yourdbname</i></span>"
+        return "<h2> READ Central Admin coming soon.</h2> <br/> <span>Try going direct to admin your database using localhost:8001/<i>yourdbname</i></span>"
 
     @app.route("/readadmin/<name>")
     def unknown(name):

--- a/common/php/utils.php
+++ b/common/php/utils.php
@@ -1127,7 +1127,8 @@ function getCustomTags($trmID,$ctxPos = "") {
 
 function getTagGIDValue($trmID) {
   $annoRepresentations = new Annotations("ano_type_id = $trmID and not ano_owner_id in (2,3,6)".
-                                              " and ano_owner_id in (".join(",",getUserMembership()).")",
+                                          " and not 5 = ANY(ano_visibility_ids)".
+                                          " and ano_owner_id in (".join(",",getUserMembership()).")",
                                           "ano_text",null,null);
   if ($annoRepresentations && $annoRepresentations->getCount() > 0 ) {
     return "ano:".$annoRepresentations->current()->getID();

--- a/dev/calcWordLocations.php
+++ b/dev/calcWordLocations.php
@@ -110,7 +110,7 @@
     <title>Calculate Edition Word Locations</title>
     <link rel="stylesheet" href="/jqwidget/jqwidgets/styles/jqx.base.css" type="text/css" />
     <link rel="stylesheet" href="/jqwidget/jqwidgets/styles/jqx.energyblue.css" type="text/css" />
-    <link rel="stylesheet" href="./css/readviewer.css" type="text/css" />
+    <link rel="stylesheet" href="../viewer/css/readviewer.css" type="text/css" />
     <script src="/jquery/jquery-1.11.1.min.js"></script>
     <script src="/jqwidget/jqwidgets/jqxcore.js"></script>
     <script src="/jqwidget/jqwidgets/jqxtouch.js"></script>

--- a/editors/js/imageVE.js
+++ b/editors/js/imageVE.js
@@ -320,6 +320,7 @@ savePolygons: function () {
     savedata["segs"] = segs;
     $.ajax({
         dataType: 'json',
+        type: 'post',
         url: basepath+'/services/updateSegments.php?db='+dbName, //TODO: convert this to saveSegment service with update cache model
         data: savedata,
         asynch: true,

--- a/editors/js/paleoVE.js
+++ b/editors/js/paleoVE.js
@@ -800,6 +800,7 @@ EDITORS.PaleoVE.prototype = {
     curCellNum = 0;
     curRowLabel = '';
     //iterate through all syllable groups and calculate sclCells
+    firstChartRow = true;
     for (gSort in paleoVE.sclCellsBySortCode) {
       sclCell = paleoVE.sclCellsBySortCode[gSort];
       if (sclCell) { //output syllable cell
@@ -810,6 +811,11 @@ EDITORS.PaleoVE.prototype = {
               curRow.append($('<div class="paleoChartCell"/>'));//mark it so dblclick has context
             }
             curRow.append($('<div class="padCell"/>'));//scrollbar space
+            //mark the first rows first cell
+          }
+          if (curRow && firstChartRow) {
+            curRow.find('.paleoChartCell:first').addClass('firstChartCell');
+            firstChartRow = false;
           }
           curCellNum = 0;
           if (sclCell.rLabel) {
@@ -838,6 +844,10 @@ EDITORS.PaleoVE.prototype = {
         curRow.append($('<div class="paleoChartCell">'));
       }
       curRow.append($('<div class="padCell">'));//scrollbar space
+    }
+    // mark last chart cell
+    if (curRow){
+      curRow.find('.paleoChartCell:last').addClass('lastChartCell');
     }
     paleoVE.addEventHandlers();
   },
@@ -888,6 +898,9 @@ EDITORS.PaleoVE.prototype = {
             segDiv.addClass('seg'+syllable.segID);
           }
         }
+      }
+      if (!url) {
+        segDiv.addClass('noglyphs');
       }
       if (segImg) {
         segImg.attr('src',(url?url:defaultUrl));
@@ -1142,7 +1155,9 @@ EDITORS.PaleoVE.prototype = {
         }
       }
       // if at the current cell there isn't any pictures, and you are not at the last cell, then go to the next cell
-      if($('div.selectedd', paleoVE.contentDiv).children().length===0 && curPaleoCell[0]!=curPaleoCell.parent().parent().children().last(".paleoChartRow").children(".paleoChartCell").last()[0]){
+      if (($('div.selectedd .noglyphs', paleoVE.contentDiv).length!==0 ||
+           $('div.selectedd', paleoVE.contentDiv).children().length===0) &&
+          !curPaleoCell.hasClass('lastChartCell')){
         btnNextCellClickHandler(paleoVE);
       }
     };
@@ -1176,7 +1191,9 @@ EDITORS.PaleoVE.prototype = {
       }
 
       // if at the current cell there isn't any pictures, and you are not at the first cell, then go to the previous cell
-      if($('div.selectedd', paleoVE.contentDiv).children().length===0 && curPaleoCell.parent().prev(".paleoChartRow").length!=0){
+      if (($('div.selectedd .noglyphs', paleoVE.contentDiv).length!==0 ||
+           $('div.selectedd', paleoVE.contentDiv).children().length===0) &&
+          !curPaleoCell.hasClass('firstChartCell')){
         btnPrevCellClickHandler(paleoVE);
       }
     };

--- a/model/entities/Token.php
+++ b/model/entities/Token.php
@@ -220,7 +220,7 @@
         $this->_graphemes = null; // and ensure refresh
       }
       $graphemes = $this->getGraphemes(true);
-      $value = null;
+      $value = $sort = $sort2 = null;
       $transcription = null;
       if (@$graphemes){
         $value = "";
@@ -481,9 +481,13 @@
         if (strpos($this->idsToString($this->_grapheme_ids),"-") !== false){ //found temp id
           $this->_graphemes = null;
         }else{
-          $this->_graphemes = new Graphemes("gra_id in (".join(",",$this->getGraphemeIDs()).")",null,null,null);
-          $this->_graphemes->setAutoAdvance(false);
-          $this->_graphemes->setOrderMap($this->getGraphemeIDs());//ensure the iterator will server objects as in order list of ids.
+          $this->_graphemes = new Graphemes("gra_id in (".join(",",$this->getGraphemeIDs()).") and not gra_owner_id = 1",null,null,null);
+          if ($this->_graphemes && $this->_graphemes->getCount() > 0) {
+            $this->_graphemes->setAutoAdvance(false);
+            $this->_graphemes->setOrderMap($this->getGraphemeIDs());//ensure the iterator will server objects as in order list of ids.
+          } else {
+            $this->_graphemes = null;
+          }
         }
       }
       return $this->_graphemes;

--- a/model/term.sql
+++ b/model/term.sql
@@ -1110,7 +1110,7 @@ INSERT INTO term ("trm_id", "trm_labels","trm_parent_id","trm_type_id","trm_list
 (1138,'en=>"Declension"',1135,806,'{452,453,454,455,456,457,458,459,460,461,462,463,464,465,466,467,468,469,470,471,472,473}','A Term record with a constrained vocabulary derived from Declemsion.','lem_declension_id','http://www.gandhari.org/kanishka/model/document/Lemma-Declension.htm',NULL,NULL,1,'{2}'),
 (1139,'en=>"HomographOrder"',1135,531,NULL,'Numeric identifier to disambiguate Homographs','lem_homographOrder','http://www.gandhari.org/kanishka/model/document/Lemma-Lemma-HomographOrder.htm',NULL,NULL,1,'{2}'),
 (1140,'en=>"ID"',1135,784,'{1135}',NULL,'lem_id','http://www.gandhari.org/kanishka/model/document/Lemma-Lemma-ID.htm',NULL,NULL,1,'{2}'),
-(1141,'en=>"Lemma"',1135,785,NULL,'The Citation Form of the Lemma.  The Language of the Lemma is identified through its inclusion in a Catalog of Catalog-Type of ''Glossary'' or ''Dictionary'' and specification in the Catalog-SourceLanguage field. Lemma-Lemma may, in circumstances where the only Attested Form of a Token or Compound has Text Critical Marks, include those Text Critical Marks.  Lemma-Lemma may also include Morpheme markers implemented as a center dot character.  Need to elaborate on the actual character.  (middle dot Alt+183/U+00B7 )','lem_value','http://www.gandhari.org/kanishka/model/document/Lemma-Lemma-Lemma.htm',NULL,NULL,1,'{2}'),
+(1141,'en=>"Lemma"',1135,785,NULL,'The Citation Form of the Lemma.  The Language of the Lemma is identified through its inclusion in a Catalog of Catalog-Type of ''Glossary'' or ''Dictionary'' and specification in the Catalog-SourceLanguage field. Lemma-Lemma may, in circumstances where the only Attested Form of a Token or Compound has Text Critical Marks, include those Text Critical Marks.  Lemma-Lemma may also include Morpheme markers implemented as a center dot character.  Need to elaborate on the actual character.  (middle dot Alt+183/U+00B7)','lem_value','http://www.gandhari.org/kanishka/model/document/Lemma-Lemma-Lemma.htm',NULL,NULL,1,'{2}'),
 (1142,'en=>"Search"',1141,785,NULL,'The search value of the Lemma.  Lemma-Search is calculated from Lemma-Lemma by stripping out any Text Critical Marks and Morpheme markers.','lem_search','http://www.gandhari.org/kanishka/model/document/Lemma-Lemma-Search.htm',NULL,NULL,1,'{2}'),
 (1143,'en=>"NominalGender"',1141,806,'{489,490,491,492,493,494,495,1383,1384}','A Term record with a constrained vocabulary derived from Gender.','lem_nominal_gender_id','http://www.gandhari.org/kanishka/model/document/Lemma-NominalGender.htm',NULL,NULL,1,'{2}'),
 (1144,'en=>"Owner"',1141,802,'{1369}','UserGroup record linked to this record.  It defines which UserGroup owns this record.','lem_owner_id','http://www.gandhari.org/kanishka/model/document/Lemma-Owner.htm',NULL,NULL,1,'{2}'),
@@ -1458,7 +1458,11 @@ INSERT INTO term ("trm_id", "trm_labels","trm_parent_id","trm_type_id","trm_list
 (1497,'en=>"Cell"',1481,778,'{1495,1496}',NULL,NULL,NULL,NULL,NULL,1,'{2}'),
 (1498,'en=>"Row"',1481,778,'{1497}',NULL,NULL,NULL,NULL,NULL,1,'{2}'),
 (1499,'en=>"Column"',1481,778,'{1497}',NULL,NULL,NULL,NULL,NULL,1,'{2}'),
-(1500,'en=>"Table"',1481,778,'{1498,1499}',NULL,NULL,NULL,NULL,NULL,1,'{2}');
+(1500,'en=>"Table"',1481,778,'{1498,1499}',NULL,NULL,NULL,NULL,NULL,1,'{2}'),
+(1501,'en=>"6"',1399,778,NULL,NULL,'ft6',NULL,NULL,NULL,1,'{2}'),
+(1502,'en=>"7"',1399,778,NULL,NULL,'ft7',NULL,NULL,NULL,1,'{2}'),
+(1503,'en=>"8"',1399,778,NULL,NULL,'ft8',NULL,NULL,NULL,1,'{2}'),
+(1504,'en=>"9"',1399,778,NULL,NULL,'ft9',NULL,NULL,NULL,1,'{2}');
 
 
-ALTER SEQUENCE term_trm_id_seq RESTART WITH 1501;
+ALTER SEQUENCE term_trm_id_seq RESTART WITH 1505;


### PR DESCRIPTION
Added more values to paleo category ft. (Note that work in progress to extend paleography categories to 6 and make them generic {4th paleo category => pc4} where each category will have 10 discrete values. Of course each research domain/language script with need to map the semantics for the categorization.)

Paleo-charts include entries with default glyphs for reconstructed values. The paleoVE has been updated to skip these with the next/prev function. (We need to consider whether to make the default configurable.)

Added to code to ensure grapheme ordering is maintained when retrieving a tokens graphemes.

Also fixed a bug in saving multiple segment changes when is was high enough the service call was hitting a URL length limit while make this a post moves this data out of the URL.